### PR TITLE
Step2 - 문자열 계산기

### DIFF
--- a/RacingCar.xcodeproj/project.pbxproj
+++ b/RacingCar.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		E26B5BE7272E541100F3DAC9 /* ExpressionUnitCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BE5272E541100F3DAC9 /* ExpressionUnitCalculator.swift */; };
 		E26B5BE9272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */; };
 		E26B5BEA272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */; };
+		E26B5BEC272E901900F3DAC9 /* ExpressionCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEB272E901900F3DAC9 /* ExpressionCalculator.swift */; };
+		E26B5BED272E901900F3DAC9 /* ExpressionCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEB272E901900F3DAC9 /* ExpressionCalculator.swift */; };
 		E26B5BEF272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
 		E26B5BF0272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
 		E2D09D8F27282B7700A846D8 /* RacingCarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */; };
@@ -36,6 +38,7 @@
 		C7E1262F27239F7E0000DB8B /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		E26B5BE5272E541100F3DAC9 /* ExpressionUnitCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionUnitCalculator.swift; sourceTree = "<group>"; };
 		E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionStringParser.swift; sourceTree = "<group>"; };
+		E26B5BEB272E901900F3DAC9 /* ExpressionCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionCalculator.swift; sourceTree = "<group>"; };
 		E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionInputError.swift; sourceTree = "<group>"; };
 		E2D09D8C27282B7700A846D8 /* RacingCarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RacingCarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RacingCarTests.swift; sourceTree = "<group>"; };
@@ -91,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */,
+				E26B5BEB272E901900F3DAC9 /* ExpressionCalculator.swift */,
 				E26B5BE5272E541100F3DAC9 /* ExpressionUnitCalculator.swift */,
 				E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */,
 			);
@@ -199,6 +203,7 @@
 				E26B5BE9272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */,
 				E26B5BE6272E541100F3DAC9 /* ExpressionUnitCalculator.swift in Sources */,
 				E26B5BEF272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */,
+				E26B5BEC272E901900F3DAC9 /* ExpressionCalculator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -212,6 +217,7 @@
 				E26B5BEA272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */,
 				E2D09D8F27282B7700A846D8 /* RacingCarTests.swift in Sources */,
 				E26B5BF0272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */,
+				E26B5BED272E901900F3DAC9 /* ExpressionCalculator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RacingCar.xcodeproj/project.pbxproj
+++ b/RacingCar.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		E26B5BED272E901900F3DAC9 /* ExpressionCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEB272E901900F3DAC9 /* ExpressionCalculator.swift */; };
 		E26B5BEF272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
 		E26B5BF0272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
+		E26B5BF5272E967500F3DAC9 /* ExpressionStringParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BF4272E967500F3DAC9 /* ExpressionStringParserTests.swift */; };
 		E2D09D8F27282B7700A846D8 /* RacingCarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */; };
 		E2D09D9327282B8E00A846D8 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E1262F27239F7E0000DB8B /* main.swift */; };
 		E2D09D9527283A4C00A846D8 /* SetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D09D9427283A4C00A846D8 /* SetTests.swift */; };
@@ -40,6 +41,7 @@
 		E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionStringParser.swift; sourceTree = "<group>"; };
 		E26B5BEB272E901900F3DAC9 /* ExpressionCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionCalculator.swift; sourceTree = "<group>"; };
 		E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionInputError.swift; sourceTree = "<group>"; };
+		E26B5BF4272E967500F3DAC9 /* ExpressionStringParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionStringParserTests.swift; sourceTree = "<group>"; };
 		E2D09D8C27282B7700A846D8 /* RacingCarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RacingCarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RacingCarTests.swift; sourceTree = "<group>"; };
 		E2D09D9427283A4C00A846D8 /* SetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTests.swift; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 			children = (
 				E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */,
 				E2D09D9427283A4C00A846D8 /* SetTests.swift */,
+				E26B5BF4272E967500F3DAC9 /* ExpressionStringParserTests.swift */,
 			);
 			path = RacingCarTests;
 			sourceTree = "<group>";
@@ -212,6 +215,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E2D09D9327282B8E00A846D8 /* main.swift in Sources */,
+				E26B5BF5272E967500F3DAC9 /* ExpressionStringParserTests.swift in Sources */,
 				E26B5BE7272E541100F3DAC9 /* ExpressionUnitCalculator.swift in Sources */,
 				E2D09D9527283A4C00A846D8 /* SetTests.swift in Sources */,
 				E26B5BEA272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */,

--- a/RacingCar.xcodeproj/project.pbxproj
+++ b/RacingCar.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		C7E1263027239F7E0000DB8B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E1262F27239F7E0000DB8B /* main.swift */; };
+		E26B5BE9272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */; };
+		E26B5BEA272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */; };
 		E26B5BEF272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
 		E26B5BF0272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
 		E2D09D8F27282B7700A846D8 /* RacingCarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */; };
@@ -30,6 +32,7 @@
 /* Begin PBXFileReference section */
 		C7E1262C27239F7E0000DB8B /* RacingCar */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RacingCar; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7E1262F27239F7E0000DB8B /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionStringParser.swift; sourceTree = "<group>"; };
 		E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionInputError.swift; sourceTree = "<group>"; };
 		E2D09D8C27282B7700A846D8 /* RacingCarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RacingCarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RacingCarTests.swift; sourceTree = "<group>"; };
@@ -84,6 +87,7 @@
 		E26B5BF1272E908900F3DAC9 /* Calculator */ = {
 			isa = PBXGroup;
 			children = (
+				E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */,
 				E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */,
 			);
 			path = Calculator;
@@ -188,6 +192,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C7E1263027239F7E0000DB8B /* main.swift in Sources */,
+				E26B5BE9272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */,
 				E26B5BEF272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -198,6 +203,7 @@
 			files = (
 				E2D09D9327282B8E00A846D8 /* main.swift in Sources */,
 				E2D09D9527283A4C00A846D8 /* SetTests.swift in Sources */,
+				E26B5BEA272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */,
 				E2D09D8F27282B7700A846D8 /* RacingCarTests.swift in Sources */,
 				E26B5BF0272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */,
 			);

--- a/RacingCar.xcodeproj/project.pbxproj
+++ b/RacingCar.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		E26B5BF0272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
 		E26B5BF5272E967500F3DAC9 /* ExpressionStringParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BF4272E967500F3DAC9 /* ExpressionStringParserTests.swift */; };
 		E288CC7E27301087005DDEF8 /* ExpressionUnitCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E288CC7D27301087005DDEF8 /* ExpressionUnitCalculatorTests.swift */; };
+		E288CC8027301B7E005DDEF8 /* ExpressionCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E288CC7F27301B7E005DDEF8 /* ExpressionCalculatorTests.swift */; };
 		E2D09D8F27282B7700A846D8 /* RacingCarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */; };
 		E2D09D9327282B8E00A846D8 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E1262F27239F7E0000DB8B /* main.swift */; };
 		E2D09D9527283A4C00A846D8 /* SetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D09D9427283A4C00A846D8 /* SetTests.swift */; };
@@ -44,6 +45,7 @@
 		E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionInputError.swift; sourceTree = "<group>"; };
 		E26B5BF4272E967500F3DAC9 /* ExpressionStringParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionStringParserTests.swift; sourceTree = "<group>"; };
 		E288CC7D27301087005DDEF8 /* ExpressionUnitCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionUnitCalculatorTests.swift; sourceTree = "<group>"; };
+		E288CC7F27301B7E005DDEF8 /* ExpressionCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionCalculatorTests.swift; sourceTree = "<group>"; };
 		E2D09D8C27282B7700A846D8 /* RacingCarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RacingCarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RacingCarTests.swift; sourceTree = "<group>"; };
 		E2D09D9427283A4C00A846D8 /* SetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTests.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 				E2D09D9427283A4C00A846D8 /* SetTests.swift */,
 				E26B5BF4272E967500F3DAC9 /* ExpressionStringParserTests.swift */,
 				E288CC7D27301087005DDEF8 /* ExpressionUnitCalculatorTests.swift */,
+				E288CC7F27301B7E005DDEF8 /* ExpressionCalculatorTests.swift */,
 			);
 			path = RacingCarTests;
 			sourceTree = "<group>";
@@ -218,6 +221,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E288CC7E27301087005DDEF8 /* ExpressionUnitCalculatorTests.swift in Sources */,
+				E288CC8027301B7E005DDEF8 /* ExpressionCalculatorTests.swift in Sources */,
 				E2D09D9327282B8E00A846D8 /* main.swift in Sources */,
 				E26B5BF5272E967500F3DAC9 /* ExpressionStringParserTests.swift in Sources */,
 				E26B5BE7272E541100F3DAC9 /* ExpressionUnitCalculator.swift in Sources */,

--- a/RacingCar.xcodeproj/project.pbxproj
+++ b/RacingCar.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		E26B5BEF272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
 		E26B5BF0272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
 		E26B5BF5272E967500F3DAC9 /* ExpressionStringParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BF4272E967500F3DAC9 /* ExpressionStringParserTests.swift */; };
+		E288CC7E27301087005DDEF8 /* ExpressionUnitCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E288CC7D27301087005DDEF8 /* ExpressionUnitCalculatorTests.swift */; };
 		E2D09D8F27282B7700A846D8 /* RacingCarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */; };
 		E2D09D9327282B8E00A846D8 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E1262F27239F7E0000DB8B /* main.swift */; };
 		E2D09D9527283A4C00A846D8 /* SetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D09D9427283A4C00A846D8 /* SetTests.swift */; };
@@ -42,6 +43,7 @@
 		E26B5BEB272E901900F3DAC9 /* ExpressionCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionCalculator.swift; sourceTree = "<group>"; };
 		E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionInputError.swift; sourceTree = "<group>"; };
 		E26B5BF4272E967500F3DAC9 /* ExpressionStringParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionStringParserTests.swift; sourceTree = "<group>"; };
+		E288CC7D27301087005DDEF8 /* ExpressionUnitCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionUnitCalculatorTests.swift; sourceTree = "<group>"; };
 		E2D09D8C27282B7700A846D8 /* RacingCarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RacingCarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RacingCarTests.swift; sourceTree = "<group>"; };
 		E2D09D9427283A4C00A846D8 /* SetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTests.swift; sourceTree = "<group>"; };
@@ -109,6 +111,7 @@
 				E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */,
 				E2D09D9427283A4C00A846D8 /* SetTests.swift */,
 				E26B5BF4272E967500F3DAC9 /* ExpressionStringParserTests.swift */,
+				E288CC7D27301087005DDEF8 /* ExpressionUnitCalculatorTests.swift */,
 			);
 			path = RacingCarTests;
 			sourceTree = "<group>";
@@ -214,6 +217,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E288CC7E27301087005DDEF8 /* ExpressionUnitCalculatorTests.swift in Sources */,
 				E2D09D9327282B8E00A846D8 /* main.swift in Sources */,
 				E26B5BF5272E967500F3DAC9 /* ExpressionStringParserTests.swift in Sources */,
 				E26B5BE7272E541100F3DAC9 /* ExpressionUnitCalculator.swift in Sources */,

--- a/RacingCar.xcodeproj/project.pbxproj
+++ b/RacingCar.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		C7E1263027239F7E0000DB8B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E1262F27239F7E0000DB8B /* main.swift */; };
+		E26B5BEF272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
+		E26B5BF0272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
 		E2D09D8F27282B7700A846D8 /* RacingCarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */; };
 		E2D09D9327282B8E00A846D8 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E1262F27239F7E0000DB8B /* main.swift */; };
 		E2D09D9527283A4C00A846D8 /* SetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D09D9427283A4C00A846D8 /* SetTests.swift */; };
@@ -28,6 +30,7 @@
 /* Begin PBXFileReference section */
 		C7E1262C27239F7E0000DB8B /* RacingCar */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RacingCar; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7E1262F27239F7E0000DB8B /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionInputError.swift; sourceTree = "<group>"; };
 		E2D09D8C27282B7700A846D8 /* RacingCarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RacingCarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2D09D8E27282B7700A846D8 /* RacingCarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RacingCarTests.swift; sourceTree = "<group>"; };
 		E2D09D9427283A4C00A846D8 /* SetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTests.swift; sourceTree = "<group>"; };
@@ -73,8 +76,17 @@
 			isa = PBXGroup;
 			children = (
 				C7E1262F27239F7E0000DB8B /* main.swift */,
+				E26B5BF1272E908900F3DAC9 /* Calculator */,
 			);
 			path = RacingCar;
+			sourceTree = "<group>";
+		};
+		E26B5BF1272E908900F3DAC9 /* Calculator */ = {
+			isa = PBXGroup;
+			children = (
+				E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */,
+			);
+			path = Calculator;
 			sourceTree = "<group>";
 		};
 		E2D09D8D27282B7700A846D8 /* RacingCarTests */ = {
@@ -176,6 +188,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C7E1263027239F7E0000DB8B /* main.swift in Sources */,
+				E26B5BEF272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -186,6 +199,7 @@
 				E2D09D9327282B8E00A846D8 /* main.swift in Sources */,
 				E2D09D9527283A4C00A846D8 /* SetTests.swift in Sources */,
 				E2D09D8F27282B7700A846D8 /* RacingCarTests.swift in Sources */,
+				E26B5BF0272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RacingCar.xcodeproj/project.pbxproj
+++ b/RacingCar.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		C7E1263027239F7E0000DB8B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E1262F27239F7E0000DB8B /* main.swift */; };
+		E26B5BE6272E541100F3DAC9 /* ExpressionUnitCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BE5272E541100F3DAC9 /* ExpressionUnitCalculator.swift */; };
+		E26B5BE7272E541100F3DAC9 /* ExpressionUnitCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BE5272E541100F3DAC9 /* ExpressionUnitCalculator.swift */; };
 		E26B5BE9272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */; };
 		E26B5BEA272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */; };
 		E26B5BEF272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */; };
@@ -32,6 +34,7 @@
 /* Begin PBXFileReference section */
 		C7E1262C27239F7E0000DB8B /* RacingCar */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RacingCar; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7E1262F27239F7E0000DB8B /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		E26B5BE5272E541100F3DAC9 /* ExpressionUnitCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionUnitCalculator.swift; sourceTree = "<group>"; };
 		E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionStringParser.swift; sourceTree = "<group>"; };
 		E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionInputError.swift; sourceTree = "<group>"; };
 		E2D09D8C27282B7700A846D8 /* RacingCarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RacingCarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -88,6 +91,7 @@
 			isa = PBXGroup;
 			children = (
 				E26B5BE8272E900300F3DAC9 /* ExpressionStringParser.swift */,
+				E26B5BE5272E541100F3DAC9 /* ExpressionUnitCalculator.swift */,
 				E26B5BEE272E906B00F3DAC9 /* ExpressionInputError.swift */,
 			);
 			path = Calculator;
@@ -193,6 +197,7 @@
 			files = (
 				C7E1263027239F7E0000DB8B /* main.swift in Sources */,
 				E26B5BE9272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */,
+				E26B5BE6272E541100F3DAC9 /* ExpressionUnitCalculator.swift in Sources */,
 				E26B5BEF272E906B00F3DAC9 /* ExpressionInputError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -202,6 +207,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E2D09D9327282B8E00A846D8 /* main.swift in Sources */,
+				E26B5BE7272E541100F3DAC9 /* ExpressionUnitCalculator.swift in Sources */,
 				E2D09D9527283A4C00A846D8 /* SetTests.swift in Sources */,
 				E26B5BEA272E900300F3DAC9 /* ExpressionStringParser.swift in Sources */,
 				E2D09D8F27282B7700A846D8 /* RacingCarTests.swift in Sources */,

--- a/RacingCar/Calculator/ExpressionCalculator.swift
+++ b/RacingCar/Calculator/ExpressionCalculator.swift
@@ -34,7 +34,9 @@ struct ExpressionCalculator {
     private var childExpressionCalculator: Self {
         get throws {
             let expressionUnitCount = 3
-            let expressionUnit = try ExpressionUnitCalculator(expression.prefix(expressionUnitCount))
+            let expressionUnit = try ExpressionUnitCalculator(
+                Array(expression.prefix(expressionUnitCount))
+            )
             let calculatedValue = String(expressionUnit.calculate())
             let childExpression = [calculatedValue] + Array(expression.dropFirst(expressionUnitCount))
             

--- a/RacingCar/Calculator/ExpressionCalculator.swift
+++ b/RacingCar/Calculator/ExpressionCalculator.swift
@@ -1,0 +1,44 @@
+//
+//  ExpressionCalculator.swift
+//  RacingCar
+//
+//  Created by itzel.du on 2021/10/31.
+//
+
+import Foundation
+
+struct ExpressionCalculator {
+    private let expression: [String]
+    
+    init(expression: [String]) {
+        self.expression = expression
+    }
+    
+    func calculate() throws -> Int {
+        guard expression.count > 1
+        else { return try lastValue }
+        
+        return try childExpressionCalculator.calculate()
+    }
+    
+    private var lastValue: Int {
+        get throws {
+            guard let lastValue = expression.last,
+                  let returnValue = Int(lastValue)
+            else { throw ExpressionInputError.invalidOutput }
+            
+            return returnValue
+        }
+    }
+    
+    private var childExpressionCalculator: Self {
+        get throws {
+            let expressionUnitCount = 3
+            let expressionUnit = try ExpressionUnitCalculator(expression.prefix(expressionUnitCount))
+            let calculatedValue = String(expressionUnit.calculate())
+            let childExpression = [calculatedValue] + Array(expression.dropFirst(expressionUnitCount))
+            
+            return Self(expression: childExpression)
+        }
+    }
+}

--- a/RacingCar/Calculator/ExpressionInputError.swift
+++ b/RacingCar/Calculator/ExpressionInputError.swift
@@ -1,0 +1,14 @@
+//
+//  ExpressionInputError.swift
+//  RacingCar
+//
+//  Created by itzel.du on 2021/10/31.
+//
+
+import Foundation
+
+enum ExpressionInputError: Error {
+    case emptyInput
+    case notOperation
+    case invalidOutput
+}

--- a/RacingCar/Calculator/ExpressionStringParser.swift
+++ b/RacingCar/Calculator/ExpressionStringParser.swift
@@ -1,0 +1,24 @@
+//
+//  ExpressionStringParser.swift
+//  RacingCar
+//
+//  Created by itzel.du on 2021/10/31.
+//
+
+import Foundation
+
+struct ExpressionStringParser {
+    private let expressionString: String
+    
+    init(expressionString: String?) throws {
+        guard let expressionString = expressionString,
+              !expressionString.isEmpty
+        else { throw ExpressionInputError.emptyInput }
+        
+        self.expressionString = expressionString
+    }
+    
+    func parse(separatedBy separator: String) -> [String] {
+        expressionString.components(separatedBy: separator)
+    }
+}

--- a/RacingCar/Calculator/ExpressionUnitCalculator.swift
+++ b/RacingCar/Calculator/ExpressionUnitCalculator.swift
@@ -43,10 +43,6 @@ struct ExpressionUnitCalculator {
 }
 
 extension ExpressionUnitCalculator {
-    init(_ expressionUnit: ArraySlice<String>) throws {
-        try self.init(Array(expressionUnit))
-    }
-    
     init(_ expressionUnit: [String]) throws {
         guard
             expressionUnit.count == 3,

--- a/RacingCar/Calculator/ExpressionUnitCalculator.swift
+++ b/RacingCar/Calculator/ExpressionUnitCalculator.swift
@@ -1,0 +1,62 @@
+//
+//  ExpressionUnitCalculator.swift
+//  RacingCar
+//
+//  Created by itzel.du on 2021/10/31.
+//
+
+import Foundation
+
+struct ExpressionUnitCalculator {
+    private let lhs: Int
+    private let operation: Operation
+    private let rhs: Int
+    
+    init(lhs: Int, operation: Operation, rhs: Int) {
+        self.lhs = lhs
+        self.operation = operation
+        self.rhs = rhs
+    }
+    
+    func calculate() -> Int {
+        switch operation {
+        case .addition: return lhs + rhs
+        case .subtraction: return lhs - rhs
+        case .multiplication: return lhs * rhs
+        case .devision: return lhs / rhs
+        }
+    }
+    
+    enum Operation {
+        case addition, subtraction, multiplication, devision
+        
+        init?(operation: String) {
+            switch operation {
+            case "+": self = .addition
+            case "-": self = .subtraction
+            case "*": self = .multiplication
+            case "/": self = .devision
+            default: return nil
+            }
+        }
+    }
+}
+
+extension ExpressionUnitCalculator {
+    init(_ expressionUnit: ArraySlice<String>) throws {
+        try self.init(Array(expressionUnit))
+    }
+    
+    init(_ expressionUnit: [String]) throws {
+        guard
+            expressionUnit.count == 3,
+            let lhs = Int(expressionUnit[0]),
+            let operation = Operation(operation: expressionUnit[1]),
+            let rhs = Int(expressionUnit[2])
+        else { throw ExpressionInputError.notOperation }
+        
+        self.lhs = lhs
+        self.operation = operation
+        self.rhs = rhs
+    }
+}

--- a/RacingCarTests/ExpressionCalculatorTests.swift
+++ b/RacingCarTests/ExpressionCalculatorTests.swift
@@ -1,0 +1,55 @@
+//
+//  ExpressionCalculatorTests.swift
+//  RacingCarTests
+//
+//  Created by itzel.du on 2021/11/01.
+//
+
+import XCTest
+
+class ExpressionCalculatorTests: XCTestCase {
+    let calculator = ExpressionCalculator(expression: ["1", "+", "2", "*", "3"])
+    
+    func test_calculate_throwing_notOperation_error() {
+        let calculatorThrowingError = ExpressionCalculator(expression: ["1", "+", "2", "*"])
+        
+        XCTAssertThrowsError(
+            try calculatorThrowingError.calculate(),
+            "The ExpressionCalculator should have thrown an ExpressionInputError.notOperation"
+        ) { error in
+            XCTAssertEqual(error as? ExpressionInputError, .notOperation)
+        }
+    }
+    
+    func test_calculate_throwing_invalidOutput_error() {
+        let invalidInputs = [
+            [],
+            [""]
+        ]
+        
+        invalidInputs.forEach { invalidInput in
+            let calculatorThrowingError = ExpressionCalculator(expression: invalidInput)
+            initWithEmptyInputError(calculator: calculatorThrowingError)
+        }
+    }
+
+    
+    func test_calculate_not_throwing_error() {
+        XCTAssertNoThrow(try calculator.calculate())
+    }
+    
+    func test_calculate_return_value() {
+        XCTAssertEqual(try? calculator.calculate(), 9)
+    }
+}
+
+extension ExpressionCalculatorTests {
+    func initWithEmptyInputError(calculator calculatorThrowingError: ExpressionCalculator) {
+        XCTAssertThrowsError(
+            try calculatorThrowingError.calculate(),
+            "The ExpressionCalculator should have thrown an ExpressionInputError.invalidOutput"
+        ) { error in
+            XCTAssertEqual(error as? ExpressionInputError, .invalidOutput)
+        }
+    }
+}

--- a/RacingCarTests/ExpressionStringParserTests.swift
+++ b/RacingCarTests/ExpressionStringParserTests.swift
@@ -20,6 +20,11 @@ class ExpressionStringParserTests: XCTestCase {
     func test_init() {
         XCTAssertNoThrow(try ExpressionStringParser(expressionString: "1 + 2 - 3"))
     }
+    
+    func test_parse() {
+        let parser = try? ExpressionStringParser(expressionString: "1 + 2 - 3")
+        XCTAssertEqual(parser?.parse(separatedBy: " "), ["1", "+", "2", "-", "3"])
+    }
 }
 
 extension ExpressionStringParserTests {

--- a/RacingCarTests/ExpressionStringParserTests.swift
+++ b/RacingCarTests/ExpressionStringParserTests.swift
@@ -1,0 +1,36 @@
+//
+//  ExpressionStringParserTests.swift
+//  RacingCarTests
+//
+//  Created by itzel.du on 2021/10/31.
+//
+
+import XCTest
+import RacingCar
+
+class ExpressionStringParserTests: XCTestCase {
+    func test_ExpressionStringParser_init_throwing_error() {
+        let emptyInputs = [nil, ""]
+        
+        emptyInputs.forEach {
+            initWithEmptyInputError(expressionString: $0)
+        }
+    }
+    
+    func test_ExpressionStringParser_init() {
+        XCTAssertNoThrow(try ExpressionStringParser(expressionString: "1 + 2 - 3"))
+    }
+}
+
+extension ExpressionStringParserTests {
+    
+    // TODO: 어떻게 nil, emptyString을 합쳐야 할지 모르겠어요
+    func initWithEmptyInputError(expressionString: String?) {
+        XCTAssertThrowsError(
+            try ExpressionStringParser(expressionString: expressionString),
+            "The ExpressionStringParser should have thrown an ExpressionInputError.emptyInput"
+        ) { error in
+            XCTAssertEqual(error as? ExpressionInputError, .emptyInput)
+        }
+    }
+}

--- a/RacingCarTests/ExpressionStringParserTests.swift
+++ b/RacingCarTests/ExpressionStringParserTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import RacingCar
 
 class ExpressionStringParserTests: XCTestCase {
-    func test_ExpressionStringParser_init_throwing_error() {
+    func test_init_throwing_error() {
         let emptyInputs = [nil, ""]
         
         emptyInputs.forEach {
@@ -17,7 +17,7 @@ class ExpressionStringParserTests: XCTestCase {
         }
     }
     
-    func test_ExpressionStringParser_init() {
+    func test_init() {
         XCTAssertNoThrow(try ExpressionStringParser(expressionString: "1 + 2 - 3"))
     }
 }

--- a/RacingCarTests/ExpressionStringParserTests.swift
+++ b/RacingCarTests/ExpressionStringParserTests.swift
@@ -27,9 +27,7 @@ class ExpressionStringParserTests: XCTestCase {
     }
 }
 
-extension ExpressionStringParserTests {
-    
-    // TODO: 어떻게 nil, emptyString을 합쳐야 할지 모르겠어요
+extension ExpressionStringParserTests {    
     func initWithEmptyInputError(expressionString: String?) {
         XCTAssertThrowsError(
             try ExpressionStringParser(expressionString: expressionString),

--- a/RacingCarTests/ExpressionUnitCalculatorTests.swift
+++ b/RacingCarTests/ExpressionUnitCalculatorTests.swift
@@ -1,0 +1,53 @@
+//
+//  ExpressionUnitCalculatorTests.swift
+//  RacingCarTests
+//
+//  Created by itzel.du on 2021/11/01.
+//
+
+import XCTest
+import RacingCar
+
+class ExpressionUnitCalculatorTests: XCTestCase {
+    func test_init_throwing_error() {
+        let invalidInputs = [
+            [""],
+            ["1"],
+            ["1", "+"]
+        ]
+        
+        invalidInputs.forEach {
+            initWithEmptyInputError(input: $0)
+        }
+    }
+    
+    func test_init() {
+        XCTAssertNoThrow(try ExpressionUnitCalculator(["1", "+", "2"]))
+    }
+    
+    func test_calculate() {
+        let inputs = [
+            ["2", "+", "1"],
+            ["2", "-", "1"],
+            ["2", "*", "1"],
+            ["2", "/", "1"]
+        ]
+        let results = [3, 1, 2, 2]
+        
+        inputs.enumerated().forEach { index, input in
+            let calculator = try? ExpressionUnitCalculator(input)
+            XCTAssertEqual(calculator?.calculate(), results[index])
+        }
+    }
+}
+
+extension ExpressionUnitCalculatorTests {
+    func initWithEmptyInputError(input: [String]) {
+        XCTAssertThrowsError(
+            try ExpressionUnitCalculator(input),
+            "The ExpressionUnitCalculator should have thrown an ExpressionInputError.notOperation"
+        ) { error in
+            XCTAssertEqual(error as? ExpressionInputError, .notOperation)
+        }
+    }
+}


### PR DESCRIPTION
## PR을 보내며
습관적으로 코드를 짜다가 TDD로 하지못하고 기능 구현을 다 한 후에 테스트코드를 작성했습니다ㅠㅠ
기능 구현에 너무 집착한 나머지 다 구현한 후에야 테스트코드를 짜지 않은 것을 깨달았습니다.
다음부터는 테스트코드부터 작성한 후에 기능을 넣도록 하겠습니다.

## 구조
1. ExpressionStringParser로 문자열(String)을 문자열 배열([String])로 변환
2. 1에서 얻은 문자열 배열을 인자로 넘겨 ExpressionCalculator 인스턴스를 생성
3. ExpressionCalculator는 2에서 넘겨 받은 문자열을 ExpressionUnit으로 나눠서 계산(calculate)

## 질문

### Error Type
모든 에러를 넘겨야하는 상황에서 ExpressionInputError의 에러 케이스로 넘기는데 각 객체마다 세분화된 Error type을 만들어 사용하고 에러를 넘겨받은 쪽에서 자신에게 맞게끔 해당 에러를 다시 재 가공해서 넘겨야할까요?

### Naming
`ExpressionCalculator`는 수식을 스트링 배열 타입으로 받아서 계산하는 객체인데 객체 이름에 넘겨받는 인자에 대한 설명이 필요할까요?

### Test
테스트 코드의 일부분을 예시로 가져왔습니다.

```swift
class ExpressionStringParserTests: XCTestCase {
    func test_init_throwing_error() {
        let emptyInputs = [nil, ""]
        
        emptyInputs.forEach {
            initWithEmptyInputError(expressionString: $0)
        }
    }
}

extension ExpressionStringParserTests {    
    func initWithEmptyInputError(expressionString: String?) {
        XCTAssertThrowsError(
            try ExpressionStringParser(expressionString: expressionString),
            "The ExpressionStringParser should have thrown an ExpressionInputError.emptyInput"
        ) { error in
            XCTAssertEqual(error as? ExpressionInputError, .emptyInput)
        }
    }
}
```
동일한 에러를 발생할 수 있는 경우가 여러 개 있을 때 반복을 줄이기 위해서 `forEach` 문을 사용하였습니다. 
error 코드에서 throws 처리를 하는게 맞는지 모르겠어서 `initWithEmptyInputError` 메소드로 분리했습니다.
그냥 아래와같이 쓰는게 더 익숙한 방식일까요? 테스트코드를 거의 안써봐서 어떤게 더 자주 사용하는 방식일지 모르겠습니다.

```swift
func test_init_throwing_error() throws {
    let emptyInputs = [nil, ""]
    
    try emptyInputs.forEach {
        XCTAssertThrowsError(
            try ExpressionStringParser(expressionString: $0),
            "The ExpressionStringParser should have thrown an ExpressionInputError.emptyInput"
        ) { error in
            XCTAssertEqual(error as? ExpressionInputError, .emptyInput)
        }
    }
}
```
